### PR TITLE
feat: Add HomographyDataset class definition

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,128 @@
+# stdlib modules
+import glob
+from typing import 
+import os
+
+# third party modules
+import cv2
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataloader, Dataset
+from torchvision.transforms import ToTensor
+import torch.nn.functional as F
+
+
+class HomographyDataset(Dataset):
+    """Deep homography estimation dataset."""
+    def __init__(
+            self, 
+            base_dir, 
+            width: int = 320, 
+            height: int = 240,
+            patch_size: int = 128,
+            rho: int = 32):
+        """Constructor method.
+        ------------------------------------------------------------------------
+        Args:
+            base_dir: filepath to folder containing images of interest
+            width: image width
+            height: image height
+            patch_size: patch size
+            rho: disturbance range"""
+        self.width = width
+        self.height = height
+        self.patch_size = patch_size
+        self.rho = rho
+        self.base_dir = base_dir
+        self.__img_paths = glob.glob(os.path.join(base_dir, "*"))
+
+    def __len__(self) -> int:
+        """Dataset length method. Computes the length of the list of image file-
+        paths.
+        ------------------------------------------------------------------------
+        Returns:
+            number of images inside of dataset directory"""
+        return len(self.__img_paths)
+
+    def __get_random_square(
+            self,
+            width: int, 
+            height: int,
+            patch_size: int,
+            rho: int) -> np.ndarray:
+        """Compute random perturbed square within image and rho boundaries.
+        ------------------------------------------------------------------------
+        Args:
+            width: image width
+            height: image height
+            patch_size: patch size
+            rho: disturbance range
+        Returns:
+            points: (4, 2)-shape numpy ndarray containing perturbed corners"""
+        # define corners' relative positions
+        points = np.array([[rho, rho],
+                           [patch_size + rho, rho],
+                           [rho, patch_size + rho],
+                           [patch_size + rho, patch_size + rho]])
+        # compute corner's absolute positions
+        a = np.random.randint(low=1, high=width - 2*rho - patch_size)
+        b = np.random.randint(low=1, high=height - 2*rho - patch_size)
+        points += np.array([[a, b]])
+
+        return points
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor]:
+        """Access dataset element using an integer index. Reads image from
+        img_path at position idx from __img_paths attribute and performs prepro-
+        cessing steps to finally return two image cropped patches and their
+        corresponding homography H.
+        ------------------------------------------------------------------------
+        Args:
+            idx: integer-valued indexing value
+        Returns:
+            imgs: tensor containing both cropped patches from original and
+                  warped images
+            H: (8,)-shape tensor containing the point-difference representation
+               for the Homography relating original and warped images
+            """
+        # read and resize grayscale image
+        img = cv2.imread(__img_paths[idx], 0)
+        img = cv2.resize(img, (self.width, self.height))
+        img = (img - 127.5) / 127.5 # normalize
+
+        # create a random square within image and rho constraints
+        points = self.__get_random_square(self.width, 
+                                          self.height, 
+                                          self.patch_size,
+                                          self.rho)
+        
+        # perturb randomly the corners within the range [-rho, rho]
+        moved_points = points + np.random.randint(low=-self.rho,
+                                                  high=self.rho,
+                                                  size=(4, 2))
+
+        # compute homography between points and moved_points
+        H = cv2.getPerspectiveTransform(points.astype('float32'),
+                                        moved_points.astype('float32'))
+        # compute inverse
+        inv_H = np.linalg.inv(H)
+        # apply H to image
+        warped_image = cv2.warpPerspective(img, 
+                                           H_inverse, 
+                                           (self.width, self.height))
+
+        # trim images bassed on previously computed random square
+        sub_img1 = img[points[0,1]:points[2,1], points[0,0]:points[1,0]]
+        sub_img2 = warped_img[points[0,1]:points[2,1], points[0,0]:points[1,0]]
+        # convert to tensor
+        sub_img1 = torch.from_numpy(sub_img1)
+        sub_img2 = torch.from_numpy(sub_img2)
+        # stack images
+        imgs = torch.stack([sub_img1, sub_img2], dim=2)
+
+        # parameterize H using point differences
+        H = (moved_points - points).reshape(8)
+        H = torch.from_numpy(H)
+
+        return imgs, H


### PR DESCRIPTION
Add deep homography class definition, which includes the following methods:

- __init__: Constructor magic method
- __len__: Size magic method
- __get_random_square: Privete method for computing square region
- __getitem__: Access method via integer-valued key

NOTE: `prepare_data.py` may be deleted without problem. Everything was migrated to `dataset.py` script.